### PR TITLE
Update doc codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,4 @@
 # Documentation files
-docs/* @saadrahim @LisaDelaney
-*.md  @saadrahim @LisaDelaney
-*.rst  @saadrahim @LisaDelaney
-# Header directory
-library/include/*  @saadrahim @LisaDelaney
+docs/* @ROCm/rocm-documentation
+*.md @ROCm/rocm-documentation
+*.rst @ROCm/rocm-documentation


### PR DESCRIPTION
Relates to https://github.com/ROCm/ROCm/issues/2833
Set documentation team as codeowners for documentation.
Goal is to make this group of code owners reviewers when merging documentation changes.